### PR TITLE
Fix failing tests

### DIFF
--- a/src/app/components/alert/test.js
+++ b/src/app/components/alert/test.js
@@ -7,6 +7,12 @@ const props = {
 };
 
 describe('Alert', () => {
+    beforeEach(() => {
+        // Fixes issue with Animated causing jest to hang
+        // https://github.com/facebook/jest/issues/4359
+        jest.useFakeTimers()
+    });
+
     test('renders correctly with error prop', () => {
         const tree = renderer.create(<Alert {...props}/>).toJSON();
         expect(tree).toMatchSnapshot();

--- a/src/app/screens/escrow/test.js
+++ b/src/app/screens/escrow/test.js
@@ -44,6 +44,13 @@ const props = {
 };
 
 describe('Escrow', () => {
+    beforeEach(() => {
+        // Lock Time
+        jest.spyOn(Date, 'now').mockImplementation(() => 1532131200000);
+    });
+    afterEach(() => {
+        Date.now.mockRestore();
+    });
     test('renders correctly', () => {
         const tree = renderer.create((
             <Provider store={mockStore()}>


### PR DESCRIPTION
This fixes two issues with our tests which kept failing.

First is with using Animated and jest together: https://github.com/facebook/jest/issues/4359 - This was causing:

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
....
TypeError: _bezier is not a function
```

Second fix is for a component that is using moment.js and comparing to the current time. As the current time changes every time the test runs, the snapshot keeps failing.