### PR TITLE
Add ActionSheet component

### DIFF
--- a/src/app/components/action-sheet/__snapshots__/test.js.snap
+++ b/src/app/components/action-sheet/__snapshots__/test.js.snap
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionSheet renders correctly 1`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={true}
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgba(0, 50, 120, 0.8)",
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "marginLeft": 20,
+          "marginRight": 20,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "rgb(247, 247, 250)",
+            "borderRadius": 5,
+            "marginBottom": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "rgb(155, 155, 155)",
+              "fontFamily": "Poppins",
+              "fontSize": 12,
+              "paddingBottom": 15,
+              "paddingTop": 15,
+              "textAlign": "center",
+            }
+          }
+        >
+          Select a document
+        </Text>
+        <View
+          accessible={true}
+          isTVSelectable={true}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "borderTopColor": "rgb(225, 225, 225)",
+              "borderTopWidth": 1,
+              "opacity": 1,
+              "paddingBottom": 20,
+              "paddingTop": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "rgb(0, 50, 120)",
+                "fontFamily": "Poppins",
+                "textAlign": "center",
+              }
+            }
+          >
+            Passport
+          </Text>
+        </View>
+        <View
+          accessible={true}
+          isTVSelectable={true}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "borderTopColor": "rgb(225, 225, 225)",
+              "borderTopWidth": 1,
+              "opacity": 1,
+              "paddingBottom": 20,
+              "paddingTop": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "rgb(0, 50, 120)",
+                "fontFamily": "Poppins",
+                "textAlign": "center",
+              }
+            }
+          >
+            Driver's Licence
+          </Text>
+        </View>
+        <View
+          accessible={true}
+          isTVSelectable={true}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "borderTopColor": "rgb(225, 225, 225)",
+              "borderTopWidth": 1,
+              "opacity": 1,
+              "paddingBottom": 20,
+              "paddingTop": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "rgb(0, 50, 120)",
+                "fontFamily": "Poppins",
+                "textAlign": "center",
+              }
+            }
+          >
+            National ID card
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+          }
+        }
+      >
+        <View
+          accessible={true}
+          isTVSelectable={true}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgb(255, 255, 255)",
+              "borderColor": "rgb(255, 255, 255)",
+              "borderRadius": 5,
+              "borderWidth": 1,
+              "marginBottom": 10,
+              "maxWidth": 400,
+              "opacity": 1,
+              "width": "100%",
+            }
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "alignSelf": "stretch",
+                  "color": "rgb(255, 255, 255)",
+                  "fontFamily": "Poppins",
+                  "fontSize": 14,
+                  "fontWeight": "bold",
+                  "height": 45,
+                  "paddingLeft": 20,
+                  "paddingRight": 20,
+                  "paddingTop": 12,
+                  "textAlign": "center",
+                },
+                Object {
+                  "color": "rgb(0, 50, 120)",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            Cancel
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</Modal>
+`;

--- a/src/app/components/action-sheet/index.js
+++ b/src/app/components/action-sheet/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {Text, View, TouchableOpacity, Modal} from 'react-native';
+import styles from './styles';
+
+import Button from '../button';
+
+export default ({
+    open, title, options, closeText = 'Cancel', onRequestClose, onSelect,
+}) => (
+    <Modal
+        animationType="slide"
+        transparent={true} 
+        visible={open}
+        onRequestClose={onRequestClose}
+    >
+        <View style={styles.container}>
+            <View style={styles.inner}>
+                <View style={styles.options}>
+                    <Text style={styles.title}>{title}</Text>
+                    {options.map((option,i) => (
+                        <TouchableOpacity style={styles.option} onPress={() => onSelect(i)}>
+                            <Text style={styles.optionText}>{option}</Text>
+                        </TouchableOpacity>
+                    ))}
+                </View>
+                <Button
+                    label={closeText}
+                    theme="light"
+                    onPress={onRequestClose}
+                    style={{
+                        borderRadius: 5,
+                    }}
+                />
+            </View>
+        </View>
+    </Modal>
+);
+

--- a/src/app/components/action-sheet/index.js
+++ b/src/app/components/action-sheet/index.js
@@ -18,7 +18,7 @@ export default ({
                 <View style={styles.options}>
                     <Text style={styles.title}>{title}</Text>
                     {options.map((option,i) => (
-                        <TouchableOpacity style={styles.option} onPress={() => onSelect(i)}>
+                        <TouchableOpacity key={i} style={styles.option} onPress={() => onSelect(i)}>
                             <Text style={styles.optionText}>{option}</Text>
                         </TouchableOpacity>
                     ))}

--- a/src/app/components/action-sheet/index.js
+++ b/src/app/components/action-sheet/index.js
@@ -27,9 +27,7 @@ export default ({
                     label={closeText}
                     theme="light"
                     onPress={onRequestClose}
-                    style={{
-                        borderRadius: 5,
-                    }}
+                    style={styles.button}
                 />
             </View>
         </View>

--- a/src/app/components/action-sheet/styles.js
+++ b/src/app/components/action-sheet/styles.js
@@ -31,7 +31,6 @@ export default StyleSheet.create({
         fontFamily,
         color: color.blue,
         textAlign: 'center',
-        //fontWeight: 'bold',
     },
     title: {
         fontFamily,
@@ -40,5 +39,8 @@ export default StyleSheet.create({
         paddingBottom: 15,
         textAlign: 'center',
         fontSize: 12,
-    }
+    },
+    button: {
+        borderRadius: 5,
+    },
 });

--- a/src/app/components/action-sheet/styles.js
+++ b/src/app/components/action-sheet/styles.js
@@ -1,0 +1,44 @@
+import {StyleSheet} from 'react-native';
+import {
+    color,
+    fontFamily
+} from '../../styles';
+
+export default StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: color.blueOpacity80,
+    },
+    inner: {
+        flex: 1,
+        marginLeft: 20,
+        marginRight: 20,
+        justifyContent: 'flex-end',
+    },
+    options: {
+        backgroundColor: color.lightGrey,
+        marginBottom: 6,
+        borderRadius: 5,
+    },
+    option: {
+        paddingTop: 20,
+        paddingBottom: 20,
+        borderTopWidth: 1,
+        borderTopColor: color.mediumGrey,
+
+    },
+    optionText: {
+        fontFamily,
+        color: color.blue,
+        textAlign: 'center',
+        //fontWeight: 'bold',
+    },
+    title: {
+        fontFamily,
+        color: color.grey,
+        paddingTop: 15,
+        paddingBottom: 15,
+        textAlign: 'center',
+        fontSize: 12,
+    }
+});

--- a/src/app/components/action-sheet/test.js
+++ b/src/app/components/action-sheet/test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ActionSheet from './';
+
+describe('ActionSheet', () => {
+    test('renders correctly', () => {
+        const tree = renderer.create(
+            <ActionSheet
+                open={true}
+                options={[
+                    'Passport',
+                    'Driver\'s Licence',
+                    'National ID card'
+                ]}
+                title="Select a document"
+                onRequestClose={() => {}}
+            />
+        ).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/storybook/index.js
+++ b/storybook/index.js
@@ -33,6 +33,7 @@ function loadStories() {
     require('./stories/slider.js');
     require('./stories/wollo.js');
     require('./stories/searchable-list.js');
+    require('./stories/action-sheet.js');
 }
 
 configure(loadStories, module);

--- a/storybook/stories/action-sheet.js
+++ b/storybook/stories/action-sheet.js
@@ -1,0 +1,53 @@
+import React, {Component} from 'react';
+import {View, Text} from 'react-native';
+import {storiesOf} from '@storybook/react-native';
+import ActionSheet from '../../src/app/components/action-sheet';
+import Button from '../../src/app/components/button';
+
+const options = [
+    "Passport",
+    "Driver's Licence",
+    "National ID card"
+];
+
+class ActionSheetText extends Component {
+    state = {
+        open: false,
+        selectedOption: null,
+    }
+    render() {
+        return (
+            <View style={{
+                flex: 1,
+                backgroundColor: 'rgb(0, 50, 120)',
+                padding: 40,
+                justifyContent: 'center',
+            }}>
+                <Button
+                    label="Press me"
+                    onPress={() => this.setState({open: true})}
+                />
+                {this.state.selectedOption !== null &&
+                    <Text style={{color: 'white', textAlign: 'center', marginTop: 10}}>
+                        Last selected: {options[this.state.selectedOption]}
+                    </Text>
+                }
+                <ActionSheet
+                    open={this.state.open}
+                    options={options}
+                    title="Select a document"
+                    onRequestClose={() => this.setState({open: false})}
+                    onSelect={index => this.setState({
+                        open: false,
+                        selectedOption: index,
+                    })}
+                />
+            </View>
+        )
+    }
+}
+
+storiesOf('ActionSheet')
+    .add('default', () => (
+        <ActionSheetText/>
+    ));


### PR DESCRIPTION
Adds an action sheet component (very similar to the native iOS one) which works on both platforms. Uses the native modal underneath to slide up and cover the screen.

You can test via http://localhost:7007/?selectedKind=ActionSheet&selectedStory=default

![kapture 2018-09-04 at 17 26 39](https://user-images.githubusercontent.com/1318966/45044447-0c0bfe00-b068-11e8-8ffc-73309582728a.gif)
