### PR TITLE
Feature/Improve header

### DIFF
--- a/src/app/components/header/index.js
+++ b/src/app/components/header/index.js
@@ -5,19 +5,25 @@ import styles from './styles';
 
 export default ({onSettings, onBack, hideLogo, customTitle}) => (
     <View style={styles.container}>
-        {!hideLogo && !customTitle && <Logo />}
-        {
-            customTitle ? <Text style={styles.customTitle}>{customTitle}</Text> : null
-        }
-        {onSettings &&
-            <TouchableOpacity style={styles.settings} onPress={onSettings}>
-                <Image style={styles.settingsIcon} source={require('./images/settings-icon.png')} />
-            </TouchableOpacity>
-        }
-        {onBack && (
-            <TouchableOpacity style={styles.back} onPress={onBack}>
-                <Image style={styles.backIcon} source={require('./images/btn_back.png')}/>
-            </TouchableOpacity>
-        )}
+        <View style={styles.iconContainer}>
+            {onBack && (
+                <TouchableOpacity style={styles.back} onPress={onBack}>
+                    <Image style={styles.backIcon} source={require('./images/btn_back.png')}/>
+                </TouchableOpacity>
+            )}
+        </View>
+        <View style={styles.titleContainer}>
+            {!hideLogo && !customTitle && <Logo />}
+            {
+                customTitle ? <Text style={styles.customTitle}>{customTitle}</Text> : null
+            }
+        </View>
+        <View style={styles.iconContainer}>
+            {onSettings &&
+                <TouchableOpacity style={styles.settings} onPress={onSettings}>
+                    <Image style={styles.settingsIcon} source={require('./images/settings-icon.png')} />
+                </TouchableOpacity>
+            }
+        </View>
     </View>
 );

--- a/src/app/components/header/styles.js
+++ b/src/app/components/header/styles.js
@@ -53,8 +53,6 @@ export default StyleSheet.create({
         height: 11,
     },
     customTitle: {
-        marginTop: 34,
-        marginBottom: 10,
         color: color.lighterBlue,
         fontSize: 14,
     }

--- a/src/app/components/header/styles.js
+++ b/src/app/components/header/styles.js
@@ -13,9 +13,25 @@ const getPadding = (w, h) => ({
 export default StyleSheet.create({
     container: {
         backgroundColor: color.blue,
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        height: 70,
+        display: 'flex',
+        flexDirection: 'row',
+        paddingTop: 20,
+    },
+    iconContainer: {
+        width: 40,
+        display: 'flex',
+        justifyContent: 'center',
+        marginLeft: 18,
+        marginRight: 18,
+    },
+    titleContainer: {
+        flex: 1,
+        display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
-        minHeight: 30,
     },
     settingsIcon: {
         width: 18,
@@ -24,18 +40,12 @@ export default StyleSheet.create({
     settings: {
         width: btnSize,
         height: btnSize,
-        position: 'absolute',
-        top: 24,
-        right: 10,
         ...getPadding(18, 18)
     },
     back: {
         // backgroundColor: 'red',
         width: btnSize,
         height: btnSize,
-        position: 'absolute',
-        top: 24,
-        left: 10,
         ...getPadding(14, 11)
     },
     backIcon: {

--- a/src/app/components/logo/styles.js
+++ b/src/app/components/logo/styles.js
@@ -4,7 +4,5 @@ export default StyleSheet.create({
     logo: {
         width: 65,
         height: 25,
-        marginTop: 34,
-        marginBottom: 10
     }
 });

--- a/src/app/components/step-header/styles.js
+++ b/src/app/components/step-header/styles.js
@@ -5,7 +5,7 @@ export default StyleSheet.create({
     container: {
         justifyContent: 'center',
         alignItems: 'center',
-        marginTop: 20,
+        marginTop: 10,
     },
     image: {
         marginTop: 8,

--- a/storybook/stories/step-module.js
+++ b/storybook/stories/step-module.js
@@ -169,6 +169,7 @@ stories.add('header test', () => (
         pad
         onSettings={() => {}}
         onBack={() => {}}
+        customTitle="Testing"
     >
     </StepModule>
 ));

--- a/storybook/stories/step-module.js
+++ b/storybook/stories/step-module.js
@@ -159,3 +159,16 @@ stories.add('loading', () => (
         </View>
     </StepModule>
 ));
+
+
+stories.add('header test', () => (
+    <StepModule
+        title={'Header Test'}
+        icon="keys"
+        content={'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis.'}
+        pad
+        onSettings={() => {}}
+        onBack={() => {}}
+    >
+    </StepModule>
+));


### PR DESCRIPTION
Makes header more flexible (use flex layout) incase we want to change it's size. Everything is centered where needed and there's space for the left/right icons and either the pigzbe logo or custom text. A fixed height of 70 is used.

<img width="395" alt="screen shot 2018-09-12 at 09 53 32" src="https://user-images.githubusercontent.com/1318966/45413775-d7a0cf00-b671-11e8-8282-5f584b7142e0.png">
